### PR TITLE
Fix inconsistent behaviour between macOS and Linux

### DIFF
--- a/Sources/Zip/QuickZip.swift
+++ b/Sources/Zip/QuickZip.swift
@@ -40,8 +40,8 @@ extension Zip {
      - Returns: `URL` of the destination folder.
      */
     public class func quickUnzipFile(_ path: URL, progress: ((_ progress: Double) -> ())?) throws -> URL {
-        let directoryName = path.lastPathComponent.replacingOccurrences(of: ".\(path.pathExtension)", with: "")
-        let destinationUrl = FileManager.default.temporaryDirectory.appendingPathComponent(directoryName, isDirectory: true)
+        let destinationUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent(path.deletingPathExtension().lastPathComponent, isDirectory: true)
         try self.unzipFile(path, destination: destinationUrl, progress: progress)
         return destinationUrl
     }
@@ -78,7 +78,14 @@ extension Zip {
      - Returns: `URL` of the destination folder.
      */
     public class func quickZipFiles(_ paths: [URL], fileName: String, progress: ((_ progress: Double) -> ())?) throws -> URL {
-        let destinationUrl = FileManager.default.temporaryDirectory.appendingPathComponent("\(fileName).zip")
+        var fileNameWithExtension = fileName
+        if !fileName.hasSuffix(".zip") {
+            fileNameWithExtension += ".zip"
+        }
+
+        print("fileNameWithExtension: \(fileNameWithExtension)")
+
+        let destinationUrl = FileManager.default.temporaryDirectory.appendingPathComponent(fileNameWithExtension)
         try self.zipFiles(paths: paths, zipFilePath: destinationUrl, progress: progress)
         return destinationUrl
     }

--- a/Sources/Zip/QuickZip.swift
+++ b/Sources/Zip/QuickZip.swift
@@ -9,15 +9,6 @@
 import Foundation
 
 extension Zip { 
-    // Get search path directory. For tvOS Documents directory doesn't exist.
-    fileprivate class var searchPathDirectory: FileManager.SearchPathDirectory {
-        #if os(tvOS)
-        .cachesDirectory
-        #else
-        .documentDirectory
-        #endif
-    }
-
     /**
      Quickly unzips a file.
      
@@ -49,11 +40,8 @@ extension Zip {
      - Returns: `URL` of the destination folder.
      */
     public class func quickUnzipFile(_ path: URL, progress: ((_ progress: Double) -> ())?) throws -> URL {
-        let fileExtension = path.pathExtension
-        let fileName = path.lastPathComponent
-        let directoryName = fileName.replacingOccurrences(of: ".\(fileExtension)", with: "")
-        let documentsUrl = FileManager.default.urls(for: self.searchPathDirectory, in: .userDomainMask)[0]
-        let destinationUrl = documentsUrl.appendingPathComponent(directoryName, isDirectory: true)
+        let directoryName = path.lastPathComponent.replacingOccurrences(of: ".\(path.pathExtension)", with: "")
+        let destinationUrl = FileManager.default.temporaryDirectory.appendingPathComponent(directoryName, isDirectory: true)
         try self.unzipFile(path, destination: destinationUrl, progress: progress)
         return destinationUrl
     }
@@ -90,8 +78,7 @@ extension Zip {
      - Returns: `URL` of the destination folder.
      */
     public class func quickZipFiles(_ paths: [URL], fileName: String, progress: ((_ progress: Double) -> ())?) throws -> URL {
-        let documentsUrl = FileManager.default.urls(for: self.searchPathDirectory, in: .userDomainMask)[0] as URL
-        let destinationUrl = documentsUrl.appendingPathComponent("\(fileName).zip")
+        let destinationUrl = FileManager.default.temporaryDirectory.appendingPathComponent("\(fileName).zip")
         try self.zipFiles(paths: paths, zipFilePath: destinationUrl, progress: progress)
         return destinationUrl
     }

--- a/Tests/ZipTests/ZipTests.swift
+++ b/Tests/ZipTests/ZipTests.swift
@@ -119,7 +119,7 @@ final class ZipTests: XCTestCase {
     func testQuickZip() throws {
         let imageURL1 = url(forResource: "3crBXeO", withExtension: "gif")!
         let imageURL2 = url(forResource: "kYkLkPf", withExtension: "gif")!
-        let destinationURL = try Zip.quickZipFiles([imageURL1, imageURL2], fileName: "archive")
+        let destinationURL = try Zip.quickZipFiles([imageURL1, imageURL2], fileName: "archive.zip")
         XCTAssertTrue(FileManager.default.fileExists(atPath: destinationURL.path))
         try XCTAssertGreaterThan(Data(contentsOf: destinationURL).count, 0)
         addTeardownBlock {


### PR DESCRIPTION
Fix a bug appearing only in Linux where the destination file of a quick zip couldn't be found.

This error didn't occur in previous versions because in macOS it was saved to the Documents directory and in Linux to the temporary directory.

Now on both platforms it saves it to the temporary directory.

(This bug causes [PassKit tests](https://github.com/vapor-community/PassKit/actions/runs/10557481086/job/29327584848#step:5:2546) to fail)